### PR TITLE
Removed a throws declaration that is not needed.

### DIFF
--- a/src/main/java/nl/tudelft/jpacman/Launcher.java
+++ b/src/main/java/nl/tudelft/jpacman/Launcher.java
@@ -198,10 +198,8 @@ public class Launcher {
      *
      * @param args
      *            The command line arguments - which are ignored.
-     * @throws IOException
-     *             When a resource could not be read.
      */
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) {
         new Launcher().launch();
     }
 }


### PR DESCRIPTION
The IOException will not be thrown by an invoked method, so it is not needed.
